### PR TITLE
move targets to project rootDirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+/bazel-out
 
 # dependencies
 /node_modules

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,49 +1,26 @@
 load("@npm//@angular/cli:index.bzl", "ng", "ng_test")
 
-ng(
-    name = "build",
-    args = [
-        "build",
-        "bazel-is-cool",
-        "--outputPath=$@",
-    ],
-    data = glob(
-        [
-            "apps/bazel-is-cool/src/*",
-            "apps/bazel-is-cool/src/**",
-            "libs/parent/some-cool-lib/*",
-            "libs/parent/some-cool-lib/**",
-        ],
-        exclude = [
-            "apps/bazel-is-cool/src/**/*.spec.ts",
-            "apps/bazel-is-cool/src/test-setup.ts",
-        ],
-    ) + [
-        "angular.json",
-        "apps/bazel-is-cool/tsconfig.json",
-        "apps/bazel-is-cool/tsconfig.app.json",
+exports_files(
+    [
         "tsconfig.json",
-        "@npm//:node_modules",
+        "tslint.json",
+        "package.json",
+        "angular.json",
+        "nx.json",
+        "jest.config.js",
     ],
-    output_dir = True,
+    visibility = ["//:__subpackages__"],
 )
 
-ng_test(
-    name = "test",
-    args = [
-        "test",
-        "bazel-is-cool",
-    ],
-    data = glob([
-        "apps/bazel-is-cool/src/*",
-        "apps/bazel-is-cool/src/**",
-    ]) + [
-        "angular.json",
-        "jest.config.js",
-        "apps/bazel-is-cool/jest.config.js",
-        "apps/bazel-is-cool/tsconfig.json",
-        "apps/bazel-is-cool/tsconfig.spec.json",
-        "tsconfig.json",
-        "@npm//:node_modules",
-    ],
+filegroup(
+    name = "node-modules",
+    srcs = [
+        "yarn.lock",
+        "@npm//:node_modules"
+    ] + glob([
+        "node_modules/**", # Need to add for tslint to find custom rules
+    ], exclude = [
+        "node_modules/fileset/test/**"
+    ]),
+    visibility = ["//visibility:public"],
 )

--- a/apps/bazel-is-cool/BUILD.bazel
+++ b/apps/bazel-is-cool/BUILD.bazel
@@ -1,0 +1,83 @@
+load("@npm//@angular/cli:index.bzl", "ng", "ng_test")
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "src/**",
+    ],
+    exclude = [
+        "**/*.spec.ts",
+    ]),
+)
+
+filegroup(
+    name = "test-srcs",
+    srcs = glob([
+        "**/*.spec.ts",
+    ]) + [
+        ":srcs",
+    ],
+)
+
+ng(
+    name = "build",
+    args = [
+        "build",
+        "bazel-is-cool",
+        "--outputPath=$@",
+    ],
+    data = [
+        "browserslist",
+        "tsconfig.app.json",
+        "tsconfig.json",
+        ":srcs",
+        "//:angular.json",
+        "//:node-modules",
+        "//:package.json",
+        "//:tsconfig.json",
+        "//libs/parent/some-cool-lib:srcs",
+    ],
+    output_dir = True,
+)
+
+ng_test(
+    name = "test",
+    args = [
+        "test",
+        "bazel-is-cool",
+    ],
+    data = [
+        "jest.config.js",
+        "tsconfig.json",
+        "tsconfig.spec.json",
+        ":test-srcs",
+        "//:angular.json",
+        "//:node-modules",
+        "//:package.json",
+        "//:tsconfig.json",
+        "//:jest.config.js",
+        "//libs/parent/some-cool-lib:srcs",
+    ],
+)
+
+ng_test(
+    name = "lint",
+    args = [
+        "lint",
+        "bazel-is-cool",
+    ],
+    data = [
+        "tsconfig.app.json",
+        "tsconfig.json",
+        "tsconfig.spec.json",
+        "tslint.json",
+        ":test-srcs",
+        "//:angular.json",
+        "//:node-modules",
+        "//:nx.json",
+        "//:package.json",
+        "//:tsconfig.json",
+        "//:tslint.json",
+        "//libs/parent/some-cool-lib:srcs",
+    ],
+)

--- a/apps/bazel-is-cool/src/test-setup.ts
+++ b/apps/bazel-is-cool/src/test-setup.ts
@@ -1,1 +1,2 @@
 import 'jest-preset-angular';
+console.log('hi');

--- a/bazel-out
+++ b/bazel-out
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_mrmeku/2862b1b0ca0f4fada19488b52142c2e3/execroot/prototype_nx_bazel/bazel-out

--- a/libs/parent/some-cool-lib/BUILD.bazel
+++ b/libs/parent/some-cool-lib/BUILD.bazel
@@ -1,0 +1,62 @@
+load("@npm//@angular/cli:index.bzl", "ng", "ng_test")
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "src/**",
+    ],
+    exclude = [
+        "**/*.spec.ts",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "test-srcs",
+    srcs = glob([
+        "**/*.spec.ts",
+    ]) + [
+        ":srcs",
+    ],
+
+)
+
+ng_test(
+    name = "test",
+    args = [
+        "test",
+        "parent-some-cool-lib",
+    ],
+    data = [
+        "jest.config.js",
+        "tsconfig.json",
+        "tsconfig.spec.json",
+        ":test-srcs",
+        "//:angular.json",
+        "//:node-modules",
+        "//:package.json",
+        "//:tsconfig.json",
+        "//:jest.config.js",
+    ],
+)
+
+ng_test(
+    name = "lint",
+    args = [
+        "lint",
+        "parent-some-cool-lib",
+    ],
+    data = [
+        "tsconfig.lib.json",
+        "tsconfig.json",
+        "tsconfig.spec.json",
+        "tslint.json",
+        ":test-srcs",
+        "//:tsconfig.json",
+        "//:tslint.json",
+        "//:nx.json",
+        "//:angular.json",
+        "//:package.json",
+        "//:node-modules",
+    ],
+)

--- a/libs/parent/some-cool-lib/src/lib/pickles.component.ts
+++ b/libs/parent/some-cool-lib/src/lib/pickles.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'pickles',
+  selector: 'app-pickles',
   templateUrl: './pickles.component.html',
   styleUrls: ['./pickles.component.css']
 })

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "bazel build :build",
+    "build": "bazel build apps/bazel-is-cool:build",
     "test": "ng test",
-    "lint": "ng lint",
+    "lint": "bazel test apps/bazel-is-cool:lint && bazel test libs/parent/some-cool-lib:lint",
     "e2e": "ng e2e",
     "postinstall": "patch-package && ngcc --properties es2015 browser module main --first-only"
   },


### PR DESCRIPTION
This creates `BUILD.bazel` in the respective project roots.

`test` still does not work.

```sh
bazel build apps/bazel-is-cool:build
bazel test apps/bazel-is-cool:lint
bazel test libs/parent/some-cool-lib:lint
# bazel test apps/bazel-is-cool:test
# bazel test libs/parent/some-cool-lib:test
```